### PR TITLE
Fix for input field focus in UIWebView instances

### DIFF
--- a/ZAActivityBar/ZAActivityBar.m
+++ b/ZAActivityBar/ZAActivityBar.m
@@ -542,6 +542,7 @@
             // Get rid of the stupid thing:
             [overlayWindow removeFromSuperview];
             overlayWindow = nil;
+            [[UIApplication sharedApplication].delegate.window makeKeyAndVisible];
         }
     }
 }


### PR DESCRIPTION
ZAActivityBar's overlayWindow still holds keyWindow status after
dismissal, therefore preventing input fields in UIWebView instances
from showing the keyboard.
This patch assigns keyWindow status to the UIApplication delegate's
main window to fix the issue.
